### PR TITLE
Develop working PoC of Watcher import script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# watchback
+
+Sync Elasticsearch Watchers from local JSON files to remote Elasticsearch.
+
+## Motivation
+
+[Elasticsearch X-Pack Watchers][] are great. However, they exist in the "belly"
+of Elasticsearch. In order to have off-band backups, version history and code
+reviews for Watch definitions, it is desirable to hold them as JSON files in
+VCS.
+
+This project is a simple tool to take a bunch of Watcher definition files
+and sync them to a remote Elasticsearch
+
+## Requirements
+
+Python 3 + PIP
+
+## Installation
+
+```bash
+git clone https://github.com/bigbank-as/watchback.git
+cd watchback
+pip3 install requirements.txt
+./watchback.py --help
+```
+
+## Usage
+
+```
+$ ./watchback.py --es-ca Corporate_Root_CA.crt \
+    --es-user=bruce.wayne \
+    --es-pass=IAmBatman \
+    --es-host=elasticsearch.waynecorp \
+    --es-port=9200 \
+    --watcher-dir=/home/bruce/vigilante/watchlist
+
+2018-08-02 14:07:38,554 - root - INFO - Starting to sync Watchers from local folder /home/bruce/vigilante/watchlist to remote Elasticsearch ['elasticsearch.waynecorp']:9200
+2018-08-02 14:07:38,671 - elasticsearch - INFO - GET https://elasticsearch.waynecorp:9200/ [status:200 request:0.117s]
+2018-08-02 14:07:38,681 - elasticsearch - INFO - GET https://elasticsearch.waynecorp:9200/_xpack/watcher/watch/example-watch [status:200 request:0.009s]
+2018-08-02 14:07:38,682 - root - INFO - Watcher example-watch is not up-to-date with remote Elasticsearch, it will be updated
+2018-08-02 14:07:38,682 - root - INFO - Diff between local and remote for watcher example-watch is as follows:
+2018-08-02 14:07:38,682 - root - INFO - {'dictionary_item_added': {"root['input']['search']['request']['types']", "root['actions']['my-logging-action']['logging']['level']", "root['input']['search']['request']['search_type']"}}
+2018-08-02 14:07:38,707 - elasticsearch - INFO - PUT https://elasticsearch.waynecorp:9200/_xpack/watcher/watch/example-watch [status:200 request:0.024s]
+2018-08-02 14:07:38,707 - root - INFO - Updated watcher example-watch, it is now version #6
+2018-08-02 14:07:38,707 - root - INFO - Finished importing Watchers
+```
+
+## Watcher Folder Structure
+
+The Watcher folder needs to follow a set structure:
+
+- One subfolder per Watcher
+- Watcher ID is the folder name (`example-watch`)
+- `watch.json` in the subfolder contains the Watch definition
+
+```
+watchers
+└── example-watch
+    └── watch.json
+```
+
+The sub-folder is needed for mapping the Watcher ID, as well as to facilitate
+additional documentation (README) and tests, per Watch.
+
+## Versioning
+
+This project follows [Semantic Versioning][].
+Current version of the project is pre-release (`0.x`): anything can change at any time.
+
+## License
+
+[Semantic Versioning]: https://semver.org
+[Apache-2.0 license](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
+
+[Elasticsearch X-Pack Watchers]: https://www.elastic.co/guide/en/elastic-stack-overview/current/xpack-alerting.html

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Sync Elasticsearch Watchers from local JSON files to remote Elasticsearch.
 
 ## Motivation
 
-[Elasticsearch X-Pack Watchers][] are great. However, they exist in the "belly"
+[Elasticsearch X-Pack Watchers][] are great - however, they exist in the "belly"
 of Elasticsearch. In order to have off-band backups, version history and code
 reviews for Watch definitions, it is desirable to hold them as JSON files in
 VCS.
 
 This project is a simple tool to take a bunch of Watcher definition files
-and sync them to a remote Elasticsearch
+and sync them to a remote Elasticsearch instance.
 
 ## Requirements
 
@@ -70,7 +70,7 @@ Current version of the project is pre-release (`0.x`): anything can change at an
 
 ## License
 
-[Semantic Versioning]: https://semver.org
 [Apache-2.0 license](https://tldrlegal.com/license/apache-license-2.0-(apache-2.0))
 
+[Semantic Versioning]: https://semver.org
 [Elasticsearch X-Pack Watchers]: https://www.elastic.co/guide/en/elastic-stack-overview/current/xpack-alerting.html

--- a/lib/watcherimporter.py
+++ b/lib/watcherimporter.py
@@ -1,0 +1,96 @@
+from elasticsearch.exceptions import NotFoundError
+from elasticsearch.exceptions import RequestError
+import json
+import os
+from deepdiff import DeepDiff
+
+
+class WatcherImporter:
+    WATCH_FILE_NAME = 'watch.json'
+
+    def __init__(self, elastic, watcher_dir, logger):
+        self.logger = logger
+        self.watcher_dir = watcher_dir
+        self.elastic = elastic
+
+    def selftest(self):
+        self.elastic.info()
+
+    @staticmethod
+    def read_json_file(file_path):
+        with open(file_path) as f:
+            file_content = json.load(f)
+            f.close()
+        return file_content
+
+    def read_watcher_definition(self, watcher_file):
+        if not os.path.isfile(watcher_file):
+            self.logger.error('Could not find watcher %s, skipping', watcher_file)
+            return False
+
+        try:
+            return self.read_json_file(watcher_file)
+        except ValueError:
+            self.logger.error('Invalid JSON in %s, skipping', watcher_file)
+            return False
+
+    def update_elastic(self, watcher_id, watcher_definition):
+
+        try:
+            result = self.elastic.xpack.watcher.put_watch(id=watcher_id, body=watcher_definition)
+        except RequestError as e:
+            self.logger.exception('Unable to update Elasticsearch watcher %s: %s', watcher_id, str(e))
+            return
+
+        if result.get('created'):
+            self.logger.info('Created a new watcher %s', watcher_id)
+        else:
+            self.logger.info('Updated watcher %s, it is now version #%d', watcher_id, result.get('_version', 1))
+
+    def watcher_needs_updating(self, watcher_id, watcher_definition):
+
+        """
+        Determines, if a given watcher_id definition from a local file is out-of-sync with remote Elasticsearch
+
+        :param watcher_id:
+        :param watcher_definition:
+        :return: True if local-remote watcher definitions are not in sync and remote needs updating
+        """
+        if not watcher_definition:
+            return False
+
+        try:
+            watcher_response = self.elastic.xpack.watcher.get_watch(id=watcher_id)
+        except NotFoundError:
+            self.logger.info('Watcher %s does not exist on the remote Elasticsearch, will create it', watcher_id)
+            return True
+
+        remote_watcher = watcher_response.get('watch', {})
+        diff = DeepDiff(watcher_definition, remote_watcher, ignore_order=True)
+
+        if not diff:
+            self.logger.info('Watcher %s definition is up-to-date with remote Elasticsearch, will not update it',
+                             watcher_id)
+            return False
+
+        self.logger.info('Watcher %s is not up-to-date with remote Elasticsearch, it will be updated', watcher_id)
+        self.logger.info('Diff between local and remote for watcher %s is as follows:', watcher_id)
+        self.logger.info(diff)
+
+        return True
+
+    def run(self, dry_run=False):
+
+        for watcher_id in os.listdir(self.watcher_dir):
+            watcher_path = os.path.join(self.watcher_dir, watcher_id, self.WATCH_FILE_NAME)
+
+            watcher_definition = self.read_watcher_definition(watcher_path)
+
+            if not self.watcher_needs_updating(watcher_id, watcher_definition):
+                self.logger.info('Skipping updating of watcher %s - no changes between local and remote')
+                continue
+
+            if dry_run:
+                self.logger.info('Skipping Elasticsearch update (dry_run=True) for watcher %s', watcher_id)
+            else:
+                self.update_elastic(watcher_id, watcher_definition)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+deepdiff==3.3
+elasticsearch==6.2

--- a/watchback.py
+++ b/watchback.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+import argparse
+from elasticsearch import Elasticsearch
+from ssl import create_default_context
+from lib.watcherimporter import WatcherImporter
+import logging
+from argparse import RawDescriptionHelpFormatter
+
+
+def _logger_factory():
+    logger = logging.getLogger()
+    logger.setLevel(logging.INFO)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+    return logger
+
+
+def _setup_cli_args():
+    parser = argparse.ArgumentParser(formatter_class=RawDescriptionHelpFormatter, description=r"""
+Sync Elasticsearch Watchers from local JSON files to remote Elasticsearch
+
+This program takes a directory of Elasticsearch Watchers (as JSON files)
+and syncs them to a remote Elasticsearch.
+
+Usage Example:
+
+./watchback.py --es-ca Corporate_Root_CA.crt \
+    --es-user=bruce.wayne \
+    --es-pass=YouNeverSeeMeComing \
+    --es-host=elasticsearch.localhost \
+    --es-port=9200 \
+    --watcher-dir=/home/bruce/vigilante/watchlist
+
+""")
+    parser.add_argument('--watcher-dir', metavar='dirpath', nargs='+', default='watchers',
+                        help='Directory containing watch definitions')
+    parser.add_argument('--dry-run', default=False, action='store_true',
+                        help='run validation checks, but do not actually modify anything on the remote API')
+    parser.add_argument('--es-ca', metavar='ca', default=None,
+                        help='A X509 trusted CA file to use for Elasticsearch HTTPS connections')
+    parser.add_argument('--es-host', metavar='host', required=True, nargs='+',
+                        help='Elasticsearch API hostname(s)')
+    parser.add_argument('--es-user', metavar='user', help='Username for Elasticsearch authentication', nargs='?',
+                        default=None)
+    parser.add_argument('--es-pass', metavar='pass', help='Password for Elasticsearch authentication', nargs='?',
+                        default=None)
+    parser.add_argument('--es-insecure',
+                        help='''
+                        Use unencrypted HTTP to connect to Elasticsearch.
+                        HTTPS is used when this argument is not specified.
+                        ''',
+                        action='store_true',
+                        default=False)
+    parser.add_argument('--es-port', metavar='port', type=int, help='Port of Elasticsearch API', nargs='?',
+                        default=9200)
+    return parser.parse_args()
+
+
+def main():
+    args = _setup_cli_args()
+    logger = _logger_factory()
+
+    if args.es_insecure:
+        logger.critical('I\'m sorry Dave, I\'m afraid I can\'t do that. ' +
+                        'I just prevented you from shooting your own foot with a ' +
+                        '2-barrel shotgun, loaded with glass shrapnel from broken whiskey bottles.')
+        logger.critical('Instead of disabling TLS certificate verification (--es-insecure), look up the correct ' +
+                        'CA to use and specify it using --es-ca.')
+        sys.exit(1)
+
+    watcher_dir = os.path.abspath(args.watcher_dir)
+    auth = (args.es_user, args.es_pass) if args.es_user and args.es_pass else None
+    try:
+        ssl_context = create_default_context(cafile=args.es_ca)
+    except FileNotFoundError:
+        logger.fatal('Unable to find the CA file %s', args.es_ca)
+        sys.exit(1)
+
+    elastic = Elasticsearch(
+        args.es_host,
+        http_auth=auth,
+        scheme='http' if args.es_insecure else 'https',
+        port=args.es_port,
+        ssl_context=ssl_context,
+    )
+
+    logger.info('Starting to sync Watchers from local folder %s to remote Elasticsearch %s:%d', watcher_dir,
+                args.es_host, args.es_port)
+
+    importer = WatcherImporter(elastic, args.watcher_dir, logger)
+
+    try:
+        importer.selftest()
+    except Exception as e:
+        logger.fatal('Unable to connect to Elasticsearch.')
+        logger.fatal(str(e))
+        sys.exit(1)
+
+    importer.run(args.dry_run)
+    logger.info('Finished importing Watchers')
+
+
+if __name__ == '__main__':
+    main()

--- a/watchback.py
+++ b/watchback.py
@@ -46,7 +46,7 @@ Usage Example:
                         help='run validation checks, but do not actually modify anything on the remote API')
     parser.add_argument('--es-ca', metavar='ca', default=None,
                         help='A X509 trusted CA file to use for Elasticsearch HTTPS connections')
-    parser.add_argument('--es-host', metavar='host', required=True, nargs='+',
+    parser.add_argument('--es-host', metavar='host', required=True, action='append',
                         help='Elasticsearch API hostname(s)')
     parser.add_argument('--es-user', metavar='user', help='Username for Elasticsearch authentication', nargs='?',
                         default=None)

--- a/watchers/example-watch/watch.json
+++ b/watchers/example-watch/watch.json
@@ -1,0 +1,36 @@
+{
+  "trigger": {
+    "schedule": {
+      "interval": "60m"
+    }
+  },
+  "input": {
+    "search": {
+      "request": {
+        "body": {
+          "size": 0,
+          "query": {
+            "match_all": {}
+          }
+        },
+        "indices": [
+          "*"
+        ]
+      }
+    }
+  },
+  "condition": {
+    "compare": {
+      "ctx.payload.hits.total": {
+        "gte": 1000000
+      }
+    }
+  },
+  "actions": {
+    "my-logging-action": {
+      "logging": {
+        "text": "There are {{ctx.payload.hits.total}} documents in your index. Threshold is 10."
+      }
+    }
+  }
+}


### PR DESCRIPTION
This script enables to take a folder of Elasticsearch Watchers (as JSON files) and upload them to a remote Elasticsearch instance.

- New Watches that are missing from Elasticsearch will be created
- Watches that have changed (Elasticsearch is out of sync) will be updated

This enables to:

- Hold Watch definitions not in Elasticsearch, but in VCS repo as files
- Do code reviews on Watch development
- Have a backup of Watch definitions
- Have change history for Watches

The script was custom-developed, because existing Kibana / Elasticsearch / X-Pack do not enable those use-cases and Googling for an already existing solution did not yield results.

## Use-cases not in scope

- Deleting Watches from Elasticsearch when local copy disappears
- Importing changes FROM Elasticsearch TO local files (future development?)